### PR TITLE
Make upgrade guide more clear in docs

### DIFF
--- a/source/includes/_updating.md
+++ b/source/includes/_updating.md
@@ -1,4 +1,4 @@
-# Updating From v3
+# Updating From v3 (BrowserJS)
 
 [Changelog](https://github.com/SkynetLabs/skynet-js/blob/master/CHANGELOG.md)
 
@@ -6,7 +6,7 @@
 **Table of Contents**
 
 - [Updating From v3](#updating-from-v3)
-    - [Upgrading](#upgrading)
+    - [Upgrading BrowserJS](#upgrading-browserjs)
     - [Installing a DAC](#installing-a-dac)
     - [Breaking Changes](#breaking-changes)
         - [SkyDB getJSON returns a data link instead of a revision number](#skydb-getjson-returns-a-data-link-instead-of-a-revision-number)
@@ -23,16 +23,16 @@
 
 <!-- markdown-toc end -->
 
-Version `v4` is a breaking change coming from `v3`. In addition to some major
-changes such as adding MySky and Data Access Controllers (DACs), this change
-contains many quality-of-life changes. These include making some non-async
-methods async, removing `revision` from SkyDB, and changing the return types of
-the SkyDB methods.
+`skynet-js` version `v4` is a breaking change coming from `v3`. In addition to
+some major changes such as adding MySky and Data Access Controllers (DACs), this
+change contains many quality-of-life changes. These include making some
+non-async methods async, removing `revision` from SkyDB, and changing the return
+types of the SkyDB methods.
 
 We understand that updating your code to accommodate breaking changes is
 inconvenient, so we put together this guide which we hope will be helpful.
 
-## Upgrading
+## Upgrading BrowserJS
 
 ```sh
 npm install skynet-js

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -57,7 +57,7 @@ We have SDK support for several languages:
 
 - Shell (using curl). See the [Using The Shell](#using-the-shell) section.
 - [Browser JS](https://github.com/SkynetLabs/skynet-js) **(most up-to-date)**
-- [NodeJS](https://github.com/SkynetLabs/nodejs-skynet) (missing SkyDB and MySky but mostly featureful)
+- [NodeJS](https://github.com/SkynetLabs/nodejs-skynet) (missing MySky and not as well-tested but mostly featureful)
 - [Python](https://github.com/SkynetLabs/python-skynet) (basic functionality only)
 - [Go](https://github.com/SkynetLabs/go-skynet) (basic functionality only)
 - [Skynet CLI](https://github.com/SkynetLabs/skynet-cli) (written in Go, basic functionality only).

--- a/source/v4/includes/_updating.md
+++ b/source/v4/includes/_updating.md
@@ -1,4 +1,4 @@
-# Updating From v3
+# Updating From v3 (BrowserJS)
 
 [Changelog](https://github.com/SkynetLabs/skynet-js/blob/master/CHANGELOG.md)
 
@@ -6,7 +6,7 @@
 **Table of Contents**
 
 - [Updating From v3](#updating-from-v3)
-    - [Upgrading](#upgrading)
+    - [Upgrading BrowserJS](#upgrading-browserjs)
     - [Installing a DAC](#installing-a-dac)
     - [Breaking Changes](#breaking-changes)
         - [SkyDB getJSON returns a data link instead of a revision number](#skydb-getjson-returns-a-data-link-instead-of-a-revision-number)
@@ -23,16 +23,16 @@
 
 <!-- markdown-toc end -->
 
-Version `v4` is a breaking change coming from `v3`. In addition to some major
-changes such as adding MySky and Data Access Controllers (DACs), this change
-contains many quality-of-life changes. These include making some non-async
-methods async, removing `revision` from SkyDB, and changing the return types of
-the SkyDB methods.
+`skynet-js` version `v4` is a breaking change coming from `v3`. In addition to
+some major changes such as adding MySky and Data Access Controllers (DACs), this
+change contains many quality-of-life changes. These include making some
+non-async methods async, removing `revision` from SkyDB, and changing the return
+types of the SkyDB methods.
 
 We understand that updating your code to accommodate breaking changes is
 inconvenient, so we put together this guide which we hope will be helpful.
 
-## Upgrading
+## Upgrading BrowserJS
 
 ```sh
 npm install skynet-js

--- a/source/v4/index.html.md
+++ b/source/v4/index.html.md
@@ -57,7 +57,7 @@ We have SDK support for several languages:
 
 - Shell (using curl). See the [Using The Shell](#using-the-shell) section.
 - [Browser JS](https://github.com/SkynetLabs/skynet-js) **(most up-to-date)**
-- [NodeJS](https://github.com/SkynetLabs/nodejs-skynet) (missing SkyDB and MySky but mostly featureful)
+- [NodeJS](https://github.com/SkynetLabs/nodejs-skynet) (missing MySky and not as well-tested but mostly featureful)
 - [Python](https://github.com/SkynetLabs/python-skynet) (basic functionality only)
 - [Go](https://github.com/SkynetLabs/go-skynet) (basic functionality only)
 - [Skynet CLI](https://github.com/SkynetLabs/skynet-cli) (written in Go, basic functionality only).


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

From user:

> Everything here towards the bottom seems to be BrowserJS/NPM/NodeJS: https://sdk.skynetlabs.com/?shell--cli#upgrading
